### PR TITLE
Add `name` entry in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ A string that marks the end of a special term.
 
 The name of an html element as a string. This can be anything, but a [flow content] will probably work the best.
 
+#### `name`
+
+*Optional, default is none*
+
+The optional name the element used internally by remark.
+
+
 #### `class`
 
 *Optional, default is none*

--- a/src/index.js
+++ b/src/index.js
@@ -1,66 +1,73 @@
 function plugin(options) {
-   options = options || [{
-      open: '{',
-      close: '}',
-      element: 'span',
-      class: 'term-1'
-   }, {
-      open: '{{',
-      close: '}}',
-      element: 'span',
-      class: 'term-2'
-   }]
+  options = options || [
+    {
+      open: "{",
+      close: "}",
+      element: "span",
+      class: "term-1"
+    },
+    {
+      open: "{{",
+      close: "}}",
+      element: "span",
+      class: "term-2"
+    }
+  ];
 
-   const Parser = this.Parser
-   const tokenizers = Parser.prototype.inlineTokenizers
-   const methods = Parser.prototype.inlineMethods
+  const Parser = this.Parser;
+  const tokenizers = Parser.prototype.inlineTokenizers;
+  const methods = Parser.prototype.inlineMethods;
 
-   var insertPoint = methods.indexOf('text')
+  let insertPoint = methods.indexOf("text");
 
-   options.reverse().forEach((config, idx) => {
-      //require: term.open, term.closed
-      if (config.open !== undefined && config.open !== null && config.open !== '' && config.close !== undefined && config.close !== null && config.close !== '') {
-         // default element 'span', default class 'term'
-         let name = `term_${idx}`
+  options.reverse().forEach((config, idx) => {
+    // require: term.open, term.closed
+    if (!config.open || !config.close) {
+      return;
+    }
+    // default element 'span', default class 'term'
+    const name = config.name || `term_${idx}`;
 
-         tokenizers[name] = function(eat, value, silent) {
-            if (value.startsWith(config.open)) {
-               let closeIndex = value.indexOf(config.close, config.open.length)
-               if (closeIndex !== -1) {
-                  if (silent) return true
-
-                  let term = value.substring(config.open.length, closeIndex)
-                  let toEat = value.substring(0, closeIndex + config.close.length)
-
-                  let node = {
-                     type: name,
-                     data: {
-                        hName: config.element || 'span'
-                     },
-                     children: this.tokenizeInline(term, eat.now())
-                  }
-
-                  if (config.class) {
-                     node.data.hProperties = {
-                        className: config.class
-                     }
-                  }
-
-                  eat(toEat)(node)
-               }
-            }
-         }
-
-         tokenizers[name].locator = function(value, fromIndex) {
-            return value.indexOf(config.open, fromIndex)
-         }
-
-         tokenizers[name].notInLink = true
-
-         methods.splice(insertPoint++, 0, name)
+    tokenizers[name] = function(eat, value, silent) {
+      if (!value.startsWith(config.open)) {
+        return;
       }
-   })
+      const closeIndex = value.indexOf(config.close, config.open.length);
+      if (closeIndex === -1) {
+        return;
+      }
+      if (silent) {
+        return true;
+      }
 
+      const term = value.substring(config.open.length, closeIndex);
+      const toEat = value.substring(0, closeIndex + config.close.length);
+
+      const node = {
+        type: name,
+        data: {
+          hName: config.element || "span"
+        },
+        children: this.tokenizeInline(term, eat.now())
+      };
+
+      if (config.class) {
+        node.data.hProperties = {
+          className: config.class
+        };
+      }
+
+      eat(toEat)(node);
+    };
+
+    tokenizers[name].locator = function(value, fromIndex) {
+      return value.indexOf(config.open, fromIndex);
+    };
+
+    tokenizers[name].notInLink = true;
+
+    methods.splice(insertPoint++, 0, name);
+  });
 }
 
-module.exports = plugin
+module.exports = plugin;


### PR DESCRIPTION
# allow to add a name instead of `term_<i>`

Useful for other tools like `react-markdown` 

# Misc

## remove nested blocks

instead of 

```js
if (condition) {
  // code
}
```

I used

```js
if (!condition) {
  return
}
// code
```

which reduces the indentation

### apply formatting with prettier

it's a side effect, I have prettier on my IDE