### PR TITLE
Replace 'module.exports' to 'export default`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,4 +104,4 @@ function plugin(options) {
    }
 }
 
-module.exports = plugin
+export default plugin


### PR DESCRIPTION
Now I use `remark-terms` with babel v7(for polyfill). However, due to https://github.com/webpack/webpack/issues/4039, I couldn't use `remark-terms` correctly with babel v7.

If you don't have some specific reasons to use `module.exports` syntax, please change to `export default`!